### PR TITLE
Add DexScreener tokens fetch script

### DIFF
--- a/dex_screener_tokens.py
+++ b/dex_screener_tokens.py
@@ -1,0 +1,22 @@
+import requests
+
+def fetch_all_tokens():
+    """Fetch a list of tokens from DexScreener."""
+    url = "https://api.dexscreener.com/latest/dex/tokens"
+    response = requests.get(url)
+    response.raise_for_status()
+    data = response.json()
+    return data.get("pairs", [])
+
+
+def main():
+    tokens = fetch_all_tokens()
+    for token in tokens:
+        base = token.get("baseToken", {})
+        symbol = base.get("symbol")
+        address = base.get("address")
+        print(f"{symbol} - {address}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `dex_screener_tokens.py` to list tokens from DexScreener API

## Testing
- `pip install -r requirements.txt` *(fails: no internet)*
- `python dex_screener_tokens.py` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_686e8e726df88332925fa9d3fd764eb6